### PR TITLE
Version 2.0.0-rc1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [v2.0.0-rc1] - WebForms API v1.1.0-1.0.4 - 2024-09-24
+### Changed
+- Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.
+- Updated the SDK release version.
+
+## Important Action Required
+- User needs to update the base URL in your codebase (if passing to SDK explicitly) and remove the /v1.1 component at the end of the URL for the SDK to work properly with this release.
+
 ## [v1.0.1] - WebForms API v1.1.0-1.0.3 - 2024-04-22
 ### Changed
 - Adjusted the minimum required firebase/php-jwt package version to 6.0.

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "docusign/webforms-client",
-    "description": "The DocuSign package makes integrating DocuSign into your apps and websites a super fast and painless process. The library is open sourced on GitHub, look for the docusign-webforms-php-client repository.",
+    "description": "The Docusign package makes integrating Docusign into your apps and websites a super fast and painless process. The library is open sourced on GitHub, look for the docusign-webforms-php-client repository.",
     "keywords": [
-        "DocuSign",
+        "Docusign",
         "WebForms",
         "php",
         "sdk",

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="DocuSign">
-    <description>DocuSign custom coding standard.</description>
+    <description>Docusign custom coding standard.</description>
     <rule ref="PEAR">
         <exclude name="Generic.Files.LineLength" />
     </rule>

--- a/src/Api/FormInstanceManagementApi.php
+++ b/src/Api/FormInstanceManagementApi.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -39,7 +39,7 @@ namespace DocuSign\WebForms\Api\FormInstanceManagementApi;
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 class ListInstancesOptions
@@ -88,7 +88,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 class FormInstanceManagementApi
@@ -199,7 +199,7 @@ class FormInstanceManagementApi
             throw new \InvalidArgumentException('Missing the required parameter $create_instance_body when calling createInstance');
         }
         // parse inputs
-        $resourcePath = "/accounts/{accountId}/forms/{formId}/instances";
+        $resourcePath = "/v1.1/accounts/{accountId}/forms/{formId}/instances";
         $httpBody = $_tempBody ?? ''; // $_tempBody is the method argument, if present
         $queryParams = $headerParams = $formParams = [];
         $headerParams['Accept'] ??= $this->apiClient->selectHeaderAccept(['application/json']);
@@ -242,7 +242,7 @@ class FormInstanceManagementApi
                 $httpBody,
                 $headerParams,
                 '\DocuSign\WebForms\Model\WebFormInstance',
-                '/accounts/{accountId}/forms/{formId}/instances'
+                '/v1.1/accounts/{accountId}/forms/{formId}/instances'
             );
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\DocuSign\WebForms\Model\WebFormInstance', $httpHeader), $statusCode, $httpHeader];
@@ -327,7 +327,7 @@ class FormInstanceManagementApi
             throw new \InvalidArgumentException('Missing the required parameter $instance_id when calling getInstance');
         }
         // parse inputs
-        $resourcePath = "/accounts/{accountId}/forms/{formId}/instances/{instanceId}";
+        $resourcePath = "/v1.1/accounts/{accountId}/forms/{formId}/instances/{instanceId}";
         $httpBody = $_tempBody ?? ''; // $_tempBody is the method argument, if present
         $queryParams = $headerParams = $formParams = [];
         $headerParams['Accept'] ??= $this->apiClient->selectHeaderAccept(['application/json']);
@@ -369,7 +369,7 @@ class FormInstanceManagementApi
                 $httpBody,
                 $headerParams,
                 '\DocuSign\WebForms\Model\WebFormInstance',
-                '/accounts/{accountId}/forms/{formId}/instances/{instanceId}'
+                '/v1.1/accounts/{accountId}/forms/{formId}/instances/{instanceId}'
             );
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\DocuSign\WebForms\Model\WebFormInstance', $httpHeader), $statusCode, $httpHeader];
@@ -450,7 +450,7 @@ class FormInstanceManagementApi
         }
 
         // parse inputs
-        $resourcePath = "/accounts/{accountId}/forms/{formId}/instances";
+        $resourcePath = "/v1.1/accounts/{accountId}/forms/{formId}/instances";
         $httpBody = $_tempBody ?? ''; // $_tempBody is the method argument, if present
         $queryParams = $headerParams = $formParams = [];
         $headerParams['Accept'] ??= $this->apiClient->selectHeaderAccept(['application/json']);
@@ -495,7 +495,7 @@ class FormInstanceManagementApi
                 $httpBody,
                 $headerParams,
                 '\DocuSign\WebForms\Model\WebFormInstanceList',
-                '/accounts/{accountId}/forms/{formId}/instances'
+                '/v1.1/accounts/{accountId}/forms/{formId}/instances'
             );
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\DocuSign\WebForms\Model\WebFormInstanceList', $httpHeader), $statusCode, $httpHeader];
@@ -576,7 +576,7 @@ class FormInstanceManagementApi
             throw new \InvalidArgumentException('Missing the required parameter $instance_id when calling refreshToken');
         }
         // parse inputs
-        $resourcePath = "/accounts/{accountId}/forms/{formId}/instances/{instanceId}/refresh";
+        $resourcePath = "/v1.1/accounts/{accountId}/forms/{formId}/instances/{instanceId}/refresh";
         $httpBody = $_tempBody ?? ''; // $_tempBody is the method argument, if present
         $queryParams = $headerParams = $formParams = [];
         $headerParams['Accept'] ??= $this->apiClient->selectHeaderAccept(['application/json']);
@@ -618,7 +618,7 @@ class FormInstanceManagementApi
                 $httpBody,
                 $headerParams,
                 '\DocuSign\WebForms\Model\WebFormInstance',
-                '/accounts/{accountId}/forms/{formId}/instances/{instanceId}/refresh'
+                '/v1.1/accounts/{accountId}/forms/{formId}/instances/{instanceId}/refresh'
             );
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\DocuSign\WebForms\Model\WebFormInstance', $httpHeader), $statusCode, $httpHeader];

--- a/src/Api/FormManagementApi.php
+++ b/src/Api/FormManagementApi.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -39,7 +39,7 @@ namespace DocuSign\WebForms\Api\FormManagementApi;
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 class GetFormOptions
@@ -80,7 +80,7 @@ class GetFormOptions
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 class ListFormsOptions
@@ -291,7 +291,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 class FormManagementApi
@@ -402,7 +402,7 @@ class FormManagementApi
         }
 
         // parse inputs
-        $resourcePath = "/accounts/{accountId}/forms/{formId}";
+        $resourcePath = "/v1.1/accounts/{accountId}/forms/{formId}";
         $httpBody = $_tempBody ?? ''; // $_tempBody is the method argument, if present
         $queryParams = $headerParams = $formParams = [];
         $headerParams['Accept'] ??= $this->apiClient->selectHeaderAccept(['application/json']);
@@ -447,7 +447,7 @@ class FormManagementApi
                 $httpBody,
                 $headerParams,
                 '\DocuSign\WebForms\Model\WebForm',
-                '/accounts/{accountId}/forms/{formId}'
+                '/v1.1/accounts/{accountId}/forms/{formId}'
             );
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\DocuSign\WebForms\Model\WebForm', $httpHeader), $statusCode, $httpHeader];
@@ -514,7 +514,7 @@ class FormManagementApi
         }
 
         // parse inputs
-        $resourcePath = "/accounts/{accountId}/forms";
+        $resourcePath = "/v1.1/accounts/{accountId}/forms";
         $httpBody = $_tempBody ?? ''; // $_tempBody is the method argument, if present
         $queryParams = $headerParams = $formParams = [];
         $headerParams['Accept'] ??= $this->apiClient->selectHeaderAccept(['application/json']);
@@ -573,7 +573,7 @@ class FormManagementApi
                 $httpBody,
                 $headerParams,
                 '\DocuSign\WebForms\Model\WebFormSummaryList',
-                '/accounts/{accountId}/forms'
+                '/v1.1/accounts/{accountId}/forms'
             );
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\DocuSign\WebForms\Model\WebFormSummaryList', $httpHeader), $statusCode, $httpHeader];

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -6,7 +6,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -36,7 +36,7 @@ namespace DocuSign\WebForms;
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 class Configuration
@@ -90,7 +90,7 @@ class Configuration
      *
      * @var string
      */
-    protected $host = 'https://apps-d.docusign.com/api/webforms/v1.1';
+    protected $host = 'https://apps-d.docusign.com/api/webforms';
 
     /**
      * Timeout (second) of the HTTP request, by default set to 0, no timeout
@@ -111,7 +111,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'Swagger-Codegen/1.1.0/1.0.1/php/' . PHP_VERSION;
+    protected $userAgent = 'Swagger-Codegen/1.1.0/2.0.0-rc1/php/' . PHP_VERSION;
 
     /**
      * Debug switch (default set to false)
@@ -774,7 +774,7 @@ class Configuration
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . PHP_VERSION . PHP_EOL;
         $report .= '    OpenAPI Spec Version: 1.1.0' . PHP_EOL;
-        $report .= '    SDK Package Version: 1.0.1' . PHP_EOL;
+        $report .= '    SDK Package Version: 2.0.0-rc1' . PHP_EOL;
         $report .= '    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL;
 
         return $report;

--- a/src/HeaderSelector.php
+++ b/src/HeaderSelector.php
@@ -6,7 +6,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -37,7 +37,7 @@ use \Exception;
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 class HeaderSelector

--- a/src/Model/AuthenticationMethod.php
+++ b/src/Model/AuthenticationMethod.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -38,7 +38,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description A value that most closely matches the technique your application used to authenticate the recipient / signer.
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class AuthenticationMethod

--- a/src/Model/CreateInstanceRequestBody.php
+++ b/src/Model/CreateInstanceRequestBody.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description Request body containing properties that will be used to create instance.
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class CreateInstanceRequestBody implements ModelInterface, ArrayAccess

--- a/src/Model/HttpError.php
+++ b/src/Model/HttpError.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description An error occurred while processing a request. Source - https://www.baeldung.com/rest-api-error-handling-best-practices
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class HttpError implements ModelInterface, ArrayAccess

--- a/src/Model/HttpSuccess.php
+++ b/src/Model/HttpSuccess.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description A simple response indicating success when no extra data is needed
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class HttpSuccess implements ModelInterface, ArrayAccess

--- a/src/Model/InstanceSource.php
+++ b/src/Model/InstanceSource.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -38,7 +38,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description The method through which form instance is created.
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class InstanceSource
@@ -50,6 +50,7 @@ class InstanceSource
     const API_EMBEDDED = 'API_EMBEDDED';
     const API_REMOTE = 'API_REMOTE';
     const UI_REMOTE = 'UI_REMOTE';
+    const WORKFLOW = 'WORKFLOW';
     
     /**
      * Gets allowable values of the enum
@@ -62,6 +63,7 @@ class InstanceSource
             self::API_EMBEDDED,
             self::API_REMOTE,
             self::UI_REMOTE,
+            self::WORKFLOW,
         ];
     }
 }

--- a/src/Model/ModelInterface.php
+++ b/src/Model/ModelInterface.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms\Model
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -36,7 +36,7 @@ namespace DocuSign\WebForms\Model;
  * @category Interface
  * @package DocuSign\WebForms\Model
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 interface ModelInterface

--- a/src/Model/TemplateProperties.php
+++ b/src/Model/TemplateProperties.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description Information about a DocuSign template that will be used to seed a web form.
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class TemplateProperties implements ModelInterface, ArrayAccess

--- a/src/Model/WebForm.php
+++ b/src/Model/WebForm.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -38,7 +38,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description An object that fully describes an instance of a form
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebForm extends WebFormSummary 

--- a/src/Model/WebFormComponentType.php
+++ b/src/Model/WebFormComponentType.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -38,7 +38,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description Type of components used in the web form
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormComponentType

--- a/src/Model/WebFormContent.php
+++ b/src/Model/WebFormContent.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description Container for the components map used during configuration and data collection
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormContent implements ModelInterface, ArrayAccess

--- a/src/Model/WebFormInstance.php
+++ b/src/Model/WebFormInstance.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description An object that contains the Web Form Instance required to render it  and its metadata such as created by, created time
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormInstance implements ModelInterface, ArrayAccess

--- a/src/Model/WebFormInstanceEnvelopes.php
+++ b/src/Model/WebFormInstanceEnvelopes.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -39,7 +39,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @category    Class
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormInstanceEnvelopes implements ModelInterface, ArrayAccess

--- a/src/Model/WebFormInstanceList.php
+++ b/src/Model/WebFormInstanceList.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description A list of web form instance items.
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormInstanceList implements ModelInterface, ArrayAccess

--- a/src/Model/WebFormInstanceMetadata.php
+++ b/src/Model/WebFormInstanceMetadata.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description Web Form Instance metadata containing information like created by, created time, etc.
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormInstanceMetadata implements ModelInterface, ArrayAccess

--- a/src/Model/WebFormMetadata.php
+++ b/src/Model/WebFormMetadata.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description Form metadata
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormMetadata implements ModelInterface, ArrayAccess
@@ -61,6 +61,8 @@ class WebFormMetadata implements ModelInterface, ArrayAccess
       */
     protected static $swaggerTypes = [
         'source' => '\DocuSign\WebForms\Model\WebFormSource',
+        'type' => '\DocuSign\WebForms\Model\WebFormType',
+        'source_form_id' => '?string',
         'owner' => '\DocuSign\WebForms\Model\WebFormUserInfo',
         'sender' => '\DocuSign\WebForms\Model\WebFormUserInfo',
         'last_modified_by' => '\DocuSign\WebForms\Model\WebFormUserInfo',
@@ -89,6 +91,8 @@ class WebFormMetadata implements ModelInterface, ArrayAccess
       */
     protected static $swaggerFormats = [
         'source' => null,
+        'type' => null,
+        'source_form_id' => null,
         'owner' => null,
         'sender' => null,
         'last_modified_by' => null,
@@ -138,6 +142,8 @@ class WebFormMetadata implements ModelInterface, ArrayAccess
      */
     protected static $attributeMap = [
         'source' => 'source',
+        'type' => 'type',
+        'source_form_id' => 'sourceFormId',
         'owner' => 'owner',
         'sender' => 'sender',
         'last_modified_by' => 'lastModifiedBy',
@@ -166,6 +172,8 @@ class WebFormMetadata implements ModelInterface, ArrayAccess
      */
     protected static $setters = [
         'source' => 'setSource',
+        'type' => 'setType',
+        'source_form_id' => 'setSourceFormId',
         'owner' => 'setOwner',
         'sender' => 'setSender',
         'last_modified_by' => 'setLastModifiedBy',
@@ -194,6 +202,8 @@ class WebFormMetadata implements ModelInterface, ArrayAccess
      */
     protected static $getters = [
         'source' => 'getSource',
+        'type' => 'getType',
+        'source_form_id' => 'getSourceFormId',
         'owner' => 'getOwner',
         'sender' => 'getSender',
         'last_modified_by' => 'getLastModifiedBy',
@@ -276,6 +286,8 @@ class WebFormMetadata implements ModelInterface, ArrayAccess
     public function __construct(array $data = null)
     {
         $this->container['source'] = isset($data['source']) ? $data['source'] : null;
+        $this->container['type'] = isset($data['type']) ? $data['type'] : null;
+        $this->container['source_form_id'] = isset($data['source_form_id']) ? $data['source_form_id'] : null;
         $this->container['owner'] = isset($data['owner']) ? $data['owner'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;
         $this->container['last_modified_by'] = isset($data['last_modified_by']) ? $data['last_modified_by'] : null;
@@ -334,13 +346,61 @@ class WebFormMetadata implements ModelInterface, ArrayAccess
     /**
      * Sets source
      *
-     * @param \DocuSign\WebForms\Model\WebFormSource $source The source from which the webform is created. Accepted values are [upload, templates, blank]
+     * @param \DocuSign\WebForms\Model\WebFormSource $source The source from which the webform is created. Accepted values are [templates, blank, form]
      *
      * @return $this
      */
     public function setSource($source)
     {
         $this->container['source'] = $source;
+
+        return $this;
+    }
+
+    /**
+     * Gets type
+     *
+     * @return \DocuSign\WebForms\Model\WebFormType
+     */
+    public function getType()
+    {
+        return $this->container['type'];
+    }
+
+    /**
+     * Sets type
+     *
+     * @param \DocuSign\WebForms\Model\WebFormType $type Represents webform type. Possible values are [standalone, hasEsignTemplate]
+     *
+     * @return $this
+     */
+    public function setType($type)
+    {
+        $this->container['type'] = $type;
+
+        return $this;
+    }
+
+    /**
+     * Gets source_form_id
+     *
+     * @return ?string
+     */
+    public function getSourceFormId()
+    {
+        return $this->container['source_form_id'];
+    }
+
+    /**
+     * Sets source_form_id
+     *
+     * @param ?string $source_form_id The source form id from which the webform is created.
+     *
+     * @return $this
+     */
+    public function setSourceFormId($source_form_id)
+    {
+        $this->container['source_form_id'] = $source_form_id;
 
         return $this;
     }

--- a/src/Model/WebFormProperties.php
+++ b/src/Model/WebFormProperties.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description General information about the web form that is consistent across versions
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormProperties implements ModelInterface, ArrayAccess

--- a/src/Model/WebFormSource.php
+++ b/src/Model/WebFormSource.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -38,7 +38,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description The source from which the web form is created.
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormSource
@@ -48,6 +48,7 @@ class WebFormSource
      */
     const TEMPLATES = 'templates';
     const BLANK = 'blank';
+    const FORM = 'form';
     
     /**
      * Gets allowable values of the enum
@@ -58,6 +59,7 @@ class WebFormSource
         return [
             self::TEMPLATES,
             self::BLANK,
+            self::FORM,
         ];
     }
 }

--- a/src/Model/WebFormState.php
+++ b/src/Model/WebFormState.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -38,7 +38,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description The state of the form content
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormState

--- a/src/Model/WebFormSummary.php
+++ b/src/Model/WebFormSummary.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description An object that summarizes an instance of a form that can be used to display a listing
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormSummary implements ModelInterface, ArrayAccess
@@ -64,6 +64,7 @@ class WebFormSummary implements ModelInterface, ArrayAccess
         'account_id' => '?string',
         'is_published' => '?bool',
         'is_enabled' => '?bool',
+        'is_uploaded' => '?bool',
         'has_draft_changes' => '?bool',
         'form_state' => '\DocuSign\WebForms\Model\WebFormState',
         'form_properties' => '\DocuSign\WebForms\Model\WebFormProperties',
@@ -80,6 +81,7 @@ class WebFormSummary implements ModelInterface, ArrayAccess
         'account_id' => null,
         'is_published' => null,
         'is_enabled' => null,
+        'is_uploaded' => null,
         'has_draft_changes' => null,
         'form_state' => null,
         'form_properties' => null,
@@ -117,6 +119,7 @@ class WebFormSummary implements ModelInterface, ArrayAccess
         'account_id' => 'accountId',
         'is_published' => 'isPublished',
         'is_enabled' => 'isEnabled',
+        'is_uploaded' => 'isUploaded',
         'has_draft_changes' => 'hasDraftChanges',
         'form_state' => 'formState',
         'form_properties' => 'formProperties',
@@ -133,6 +136,7 @@ class WebFormSummary implements ModelInterface, ArrayAccess
         'account_id' => 'setAccountId',
         'is_published' => 'setIsPublished',
         'is_enabled' => 'setIsEnabled',
+        'is_uploaded' => 'setIsUploaded',
         'has_draft_changes' => 'setHasDraftChanges',
         'form_state' => 'setFormState',
         'form_properties' => 'setFormProperties',
@@ -149,6 +153,7 @@ class WebFormSummary implements ModelInterface, ArrayAccess
         'account_id' => 'getAccountId',
         'is_published' => 'getIsPublished',
         'is_enabled' => 'getIsEnabled',
+        'is_uploaded' => 'getIsUploaded',
         'has_draft_changes' => 'getHasDraftChanges',
         'form_state' => 'getFormState',
         'form_properties' => 'getFormProperties',
@@ -219,6 +224,7 @@ class WebFormSummary implements ModelInterface, ArrayAccess
         $this->container['account_id'] = isset($data['account_id']) ? $data['account_id'] : null;
         $this->container['is_published'] = isset($data['is_published']) ? $data['is_published'] : null;
         $this->container['is_enabled'] = isset($data['is_enabled']) ? $data['is_enabled'] : null;
+        $this->container['is_uploaded'] = isset($data['is_uploaded']) ? $data['is_uploaded'] : null;
         $this->container['has_draft_changes'] = isset($data['has_draft_changes']) ? $data['has_draft_changes'] : null;
         $this->container['form_state'] = isset($data['form_state']) ? $data['form_state'] : null;
         $this->container['form_properties'] = isset($data['form_properties']) ? $data['form_properties'] : null;
@@ -341,6 +347,30 @@ class WebFormSummary implements ModelInterface, ArrayAccess
     public function setIsEnabled($is_enabled)
     {
         $this->container['is_enabled'] = $is_enabled;
+
+        return $this;
+    }
+
+    /**
+     * Gets is_uploaded
+     *
+     * @return ?bool
+     */
+    public function getIsUploaded()
+    {
+        return $this->container['is_uploaded'];
+    }
+
+    /**
+     * Sets is_uploaded
+     *
+     * @param ?bool $is_uploaded Has the form created through upload
+     *
+     * @return $this
+     */
+    public function setIsUploaded($is_uploaded)
+    {
+        $this->container['is_uploaded'] = $is_uploaded;
 
         return $this;
     }

--- a/src/Model/WebFormSummaryList.php
+++ b/src/Model/WebFormSummaryList.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description A list of web form summary items.
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormSummaryList implements ModelInterface, ArrayAccess

--- a/src/Model/WebFormType.php
+++ b/src/Model/WebFormType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * InstanceStatus
+ * WebFormType
  *
  * PHP version 7.4
  *
@@ -32,25 +32,22 @@ namespace DocuSign\WebForms\Model;
 use DocuSign\WebForms\ObjectSerializer;
 
 /**
- * InstanceStatus Class Doc Comment
+ * WebFormType Class Doc Comment
  *
  * @category    Class
- * @description The status of Web Form Instance. If the form status is INITIATED, it means the form is accessible until it is submitted or expired. If the form status is SUBMITTED, it means the form is submitted already and hence, cannot be opened again.
+ * @description The field indicates webform type.
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
  * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class InstanceStatus
+class WebFormType
 {
     /**
      * Possible values of this enum
      */
-    const INITIATED = 'INITIATED';
-    const IN_PROGRESS = 'IN_PROGRESS';
-    const SUBMITTED = 'SUBMITTED';
-    const EXPIRED = 'EXPIRED';
-    const FAILED = 'FAILED';
+    const STANDALONE = 'standalone';
+    const HAS_ESIGN_TEMPLATE = 'hasEsignTemplate';
     
     /**
      * Gets allowable values of the enum
@@ -59,11 +56,8 @@ class InstanceStatus
     public static function getAllowableEnumValues()
     {
         return [
-            self::INITIATED,
-            self::IN_PROGRESS,
-            self::SUBMITTED,
-            self::EXPIRED,
-            self::FAILED,
+            self::STANDALONE,
+            self::HAS_ESIGN_TEMPLATE,
         ];
     }
 }

--- a/src/Model/WebFormUserInfo.php
+++ b/src/Model/WebFormUserInfo.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description Information about a DocuSign system user. The user exists within the account associated with the form.
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormUserInfo implements ModelInterface, ArrayAccess

--- a/src/Model/WebFormValues.php
+++ b/src/Model/WebFormValues.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -40,7 +40,7 @@ use DocuSign\WebForms\ObjectSerializer;
  * @description Key-value pairs (where key is the component name and value is the form value) used to create a form instance. For key of type TextBox, Email, Date, Select and RadioButtonGroup the value is of string type. For key of type Number, the value is of number type. For key of type of CheckboxGroup, the value is of type array of string.
  * @package     DocuSign\WebForms
  * @author      Swagger Codegen team <apihelp@docusign.com>
- * @license     The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license     The Docusign PHP Client SDK is licensed under the MIT License.
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class WebFormValues implements ModelInterface, ArrayAccess

--- a/src/ObjectSerializer.php
+++ b/src/ObjectSerializer.php
@@ -7,7 +7,7 @@
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
@@ -36,7 +36,7 @@ namespace DocuSign\WebForms;
  * @category Class
  * @package  DocuSign\WebForms
  * @author   Swagger Codegen team <apihelp@docusign.com>
- * @license  The DocuSign PHP Client SDK is licensed under the MIT License.
+ * @license  The Docusign PHP Client SDK is licensed under the MIT License.
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 class ObjectSerializer

--- a/test/TestConfig.php
+++ b/test/TestConfig.php
@@ -98,7 +98,7 @@ class TestConfig
 
     public function __construct($integratorKey = null, $host = null, $returnUrl = null, $envelopeId = null, $secret = null, $key = null, $userId = null, $privateKey = null)
     {
-        $this->host = !empty($host) ? $host : 'https://demo.services.docusign.net/webforms/v1.1';
+        $this->host = !empty($host) ? $host : 'https://demo.services.docusign.net/webforms';
         $this->integratorKey = !empty($integratorKey) ? $integratorKey : getenv('INTEGRATOR_KEY');
         $this->clientSecret = !empty($secret) ? $secret : getenv('CLIENT_SECRET');
         $this->clientKey = !empty($key) ? $key : 'Docs/private.pem';


### PR DESCRIPTION
### Changed
- Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.
- Updated the SDK release version.

## Important Action Required
- User needs to update the base URL in your codebase (if passing to SDK explicitly) and remove the /v1.1 component at the end of the URL for the SDK to work properly with this release.
